### PR TITLE
Fixed logic for openHistorian Attached Paths

### DIFF
--- a/Source/Libraries/Adapters/openHistorian.Adapters/LocalOutputAdapter.cs
+++ b/Source/Libraries/Adapters/openHistorian.Adapters/LocalOutputAdapter.cs
@@ -285,10 +285,10 @@ namespace openHistorian.Adapters
                     {
                         string localPath = FilePath.GetAbsolutePath(archivePath);
 
-                        if (!Directory.Exists(localPath) || !File.Exists(localPath))
-                            OnProcessException(new InvalidOperationException($"Failed to locate \"{localPath}\""));
-                        else
+                        if (Directory.Exists(localPath) || File.Exists(localPath))
                             attachedPaths.Add(localPath);
+                        else
+                            OnProcessException(new InvalidOperationException($"Failed to locate \"{localPath}\""));
                     }
 
                     m_attachedPaths = attachedPaths.ToArray();


### PR DESCRIPTION
The previous logic to check for the existence of the user-specified AttachedPath string would always result in a "Failed to locate 'localPath'" because the string is either a File or a Directory, not both.  Edited logic to correct this.