### PR TITLE
Fix logic to handle frameBase options on Trend/Export page

### DIFF
--- a/Source/Applications/openHistorian/openHistorian/wwwroot/TrendMeasurements.cshtml
+++ b/Source/Applications/openHistorian/openHistorian/wwwroot/TrendMeasurements.cshtml
@@ -1696,10 +1696,10 @@
 
                 let adjustedFrameRate = viewModel.frameRate();
 
-                if (viewModel.frameBase() === 1)
+                if (viewModel.frameBase() == 1)
                     adjustedFrameRate = adjustedFrameRate / 60.0;
 
-                if (viewModel.frameBase() === 2)
+                if (viewModel.frameBase() == 2)
                     adjustedFrameRate = adjustedFrameRate / (60.0 * 60.0);
 
                 let tolerance = 0.5;


### PR DESCRIPTION
`<select>` elements produce string values so I modified the equality comparison to use type coercion as is done with `fileFormat` on line 1607.

https://github.com/GridProtectionAlliance/openHistorian/blob/7033b85ca2fcdd31288a99f7525d5b6a8b79b1de/Source/Applications/openHistorian/openHistorian/wwwroot/TrendMeasurements.cshtml#L1606-L1608