### PR TITLE
OH-2 Eliminate race condition in failover logic

### DIFF
--- a/Source/Applications/openHistorian/openHistorian/FailoverMiddleware.cs
+++ b/Source/Applications/openHistorian/openHistorian/FailoverMiddleware.cs
@@ -51,7 +51,7 @@ namespace openHistorian
             if (string.IsNullOrEmpty(host))
                 host = context.Request.RemoteIpAddress;
 
-            if (!Program.Host.TryFailOver(host))
+            if (!Program.Host.FailOver(host))
             {
                 context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
                 context.Response.ReasonPhrase = "Bad Request";


### PR DESCRIPTION
With this PR, if we receive a request for failover, we don't even check if the primary node is active because its web host may not be available at the point where it's requesting failover. The logic is much simpler. The web host will reject the request if the user is unauthorized. `ServiceHost` will reject the request if the node is not configured as a secondary node.