### PR TITLE
Fixes Grafana proxy errors related to addition of content security headers

### DIFF
--- a/Source/Applications/openHistorian/openHistorian/Startup.cs
+++ b/Source/Applications/openHistorian/openHistorian/Startup.cs
@@ -70,7 +70,8 @@ namespace openHistorian
                 {
                     await next();
 
-                    context.Response.Headers.Add("Content-Security-Policy", ["default-src: 'self'"]);
+                    if (!context.Response.Headers.ContainsKey("Content-Security-Policy"))
+                        context.Response.Headers.Add("Content-Security-Policy", ["default-src: 'self'"]);
 
                     if (context.Request.Scheme == "https" && !context.Response.Headers.ContainsKey("Strict-Transport-Security"))
                         context.Response.Headers.Add("Strict-Transport-Security", ["max-age=31536000", "includeSubDomains"]);

--- a/Source/openHistorian.sln.DotSettings
+++ b/Source/openHistorian.sln.DotSettings
@@ -48,6 +48,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ngen/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=NODEID/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=NOMINALFREQUENCY/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=nosniff/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Npgsql/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Numerics/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=OPTIONALINSTALLSFOLDER/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
New code update causes object disposed and argument exceptions in Grafana:
![image](https://github.com/user-attachments/assets/199622cd-3e02-4dac-a417-091e3f896ba7)

FYI - for a release deployment - this causes Grafana screen icon to bounce forever, without ever loading Grafana screen.

This fixes issue.